### PR TITLE
Prepare for changing from string run duration to seconds, optionally read records from Azure queue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+discord.py==1.7.3
+python_dateutil==2.8.2
+requests==2.27.1
+azure-storage-queue==12.1.6
+humanize==3.13.1 


### PR DESCRIPTION
- Prepare for change of run duration from string ("01:13:25") to float seconds
- Add loop to pull record info from an Azure queue instance instead of needing to diff json payloads 
    - Also will fix the issue where >4 records between checks are lost
- Add thumbnail and stream duration to stream embeds
- Editing of stream embeds to update title/viewer info
- Create `requirements.txt` to allow easier installation of dependencies via `pip install -r requirements.txt`

![image](https://user-images.githubusercontent.com/8509767/151648727-0d7a51fb-86d9-4920-b57d-b2aa313ba438.png)
